### PR TITLE
solve the issue#1: tests/server.rs fails

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,4 +1,3 @@
-// 和 server.rs 比较相似
 use clap::Parser;
 use dotenv::dotenv;
 use log::debug;
@@ -83,12 +82,12 @@ async fn main() -> Result<(), MiniRedisClientError> {
             message,
         } => {
             client.publish(&channel, message).await?;
-            println!("publish Ok");
+            println!("publish ok");
         }
 
         Command::Subscribe { channels } => {
             if channels.is_empty() {
-                return Err(MiniRedisConnectionError::InvalidArgument("channel(s) must be provided".into()).into());
+                return Err(MiniRedisConnectionError::InvalidArgument("channel(s) must be provided".into(),).into());
             }
 
             let mut subscriber = client.subscribe(channels).await?;

--- a/src/client/subscriber.rs
+++ b/src/client/subscriber.rs
@@ -20,7 +20,7 @@ pub struct Message {
 }
 
 impl Subscriber {
-    pub async fn subcribe(&mut self, channels: &[String]) -> Result<(), MiniRedisConnectionError> {
+    pub async fn subscribe(&mut self, channels: &[String]) -> Result<(), MiniRedisConnectionError> {
         self.client.subscribe_cmd(channels).await?;
 
         self.subscribed_channels
@@ -94,7 +94,10 @@ impl Subscriber {
 
                         self.subscribed_channels.retain(|c| *channel != &c[..]);
                         if self.subscribed_channels.len() != len - 1 {
-                            return Err(MiniRedisConnectionError::InvalidArgument(
+                            // return Err(MiniRedisConnectionError::InvalidArgument(
+                            //     response.to_string(),
+                            // ));
+                            return Err(MiniRedisConnectionError::CommandExecute(
                                 response.to_string(),
                             ));
                         }

--- a/src/cmd/get.rs
+++ b/src/cmd/get.rs
@@ -61,7 +61,8 @@ impl Get {
         dst: &mut Connection,
     ) -> Result<(), MiniRedisConnectionError> {
         let response = if let Some(value) = db.get(&self.key) {
-            Frame::Bulk(Bytes::from(value))
+            // Frame::Bulk(Bytes::from(value))
+            Frame::Bulk(value)
         } else {
             Frame::Null
         };

--- a/src/cmd/publish.rs
+++ b/src/cmd/publish.rs
@@ -39,7 +39,8 @@ impl Publish {
         let mut frame = Frame::array();
         frame.push_bulk(Bytes::from("publish".as_bytes()))?;
         frame.push_bulk(Bytes::from(self.channel.into_bytes()))?;
-        frame.push_bulk(Bytes::from(self.message))?;
+        // frame.push_bulk(Bytes::from(self.message))?;
+        frame.push_bulk(self.message)?;
         Ok(frame)
     }
 }

--- a/src/cmd/set.rs
+++ b/src/cmd/set.rs
@@ -86,7 +86,7 @@ impl Set {
             }
             // invalid，暂时不支持其他类型
             Ok(s) => {
-                warn!("invalid set command argument: {:?}", s);
+                warn!("invalid set command argument: {}", s);
                 return Err(MiniRedisParseError::Parse(
                     "currently `SET` only support the expiration option".into(),
                 ));

--- a/src/cmd/unknown.rs
+++ b/src/cmd/unknown.rs
@@ -21,7 +21,8 @@ impl Unknown {
     }
 
     pub(crate) async fn apply(self, dst: &mut Connection) -> Result<(), MiniRedisConnectionError> {
-        let response = Frame::Error(format!("err unknown command: '{}'", self.cmd_name));
+        // let response = Frame::Error(format!("err unknown command: '{}'", self.cmd_name));
+        let response = Frame::Error(format!("err unknown command '{}'", self.cmd_name));
         debug!("apply unknown command resp: '{:?}'", response);
         dst.write_frame(&response).await?;
         Ok(())


### PR DESCRIPTION
## Version

```
clap = { version = "3.2.23", features = ["derive"] } 
tokio = { version = "1", features = ["full"] }
tokio-stream = "0.1"
dotenv = "0.15.0"
log = "0.4"
thiserror = "1.0.38"
bytes = "1"
atoi = "2.0.0"
async-stream = "0.3.0"
```



## Platform

Windows11 x64



## Description

This is a simple problem. You only need to change this line of code in `src/cmd/unknown.rs`：

```rust
pub(crate) async fn apply(self, dst: &mut Connection) -> Result<(), MiniRedisConnectionError> {
    // let response = Frame::Error(format!("err unknown command: '{}'", self.cmd_name));
    let response = Frame::Error(format!("err unknown command '{}'", self.cmd_name));
    debug!("apply unknown command resp: '{:?}'", response);
    dst.write_frame(&response).await?;
    Ok(())
}
```

`cargo test --all` The results are as follows：

```
PS E:\mini_redis> cargo test --all
    Finished test [unoptimized + debuginfo] target(s) in 0.12s
     Running unittests src\lib.rs (target\debug\deps\mini_redis-0003053bae631cda.exe)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src\bin\cli.rs (target\debug\deps\cli-aa7259f2ff9c228b.exe)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src\bin\server.rs (target\debug\deps\server-c4c4f86ae1e4c449.exe)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests\client.rs (target\debug\deps\client-d5626382e29400eb.exe)

running 6 tests
test ping_pong_without_message ... ok
test ping_pong_with_message ... ok
test key_value_get_set ... ok
test unsubscribes_from_channels ... ok
test receive_message_subscribed_channel ... ok
test receive_message_multiple_subscribed_channels ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running tests\server.rs (target\debug\deps\server-12f3daa433f232fe.exe)

running 6 tests
test send_error_unknown_command ... ok
test key_value_get_set ... ok
test send_error_get_set_after_subscribe ... ok
test pub_sub ... ok
test manage_subscription ... ok
test key_value_timeout ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.02s

   Doc-tests mini-redis

running 1 test
test src\server\mod.rs - server::run (line 27) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.56s
```